### PR TITLE
feat: 반경 내 사용자 필터링 유틸(VicinityUserFinder) 구현 및 테스트

### DIFF
--- a/src/main/java/com/smooth/alert_service/domain/EventType.java
+++ b/src/main/java/com/smooth/alert_service/domain/EventType.java
@@ -1,0 +1,39 @@
+package com.smooth.alert_service.domain;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum EventType {
+    ACCIDENT("accident", 300),
+    OBSTACLE("obstacle", 100),
+    POTHOLE("pothole", 50),
+    START("start", 0),
+    END("end", 0);
+
+    private final String type;
+    private final int radiusMeters;
+
+    EventType(String type, int radiusMeters) {
+        this.type = type;
+        this.radiusMeters = radiusMeters;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getRadiusMeters() {
+        return radiusMeters;
+    }
+
+    public static Optional<EventType> from(String type) {
+        return Arrays.stream(values())
+                .filter(t -> t.type.equalsIgnoreCase(type))
+                .findFirst();
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+}

--- a/src/main/java/com/smooth/alert_service/service/VicinityUserFinder.java
+++ b/src/main/java/com/smooth/alert_service/service/VicinityUserFinder.java
@@ -1,0 +1,53 @@
+package com.smooth.alert_service.service;
+
+import com.smooth.alert_service.domain.EventType;
+import com.smooth.alert_service.dto.AlertEvent;
+import org.springframework.data.geo.*;
+import org.springframework.data.redis.connection.RedisGeoCommands;
+import org.springframework.data.redis.core.GeoOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class VicinityUserFinder {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public VicinityUserFinder(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public List<String> findNearbyUsers(AlertEvent event) {
+        var typeOpt = EventType.from(event.type());
+        if (typeOpt.isEmpty()) {
+            throw new IllegalArgumentException("Unsupported event type: " + event.type());
+        }
+
+        int radius = typeOpt.get().getRadiusMeters();
+        if (radius == 0) return List.of();
+
+        if (event.latitude() == null || event.longitude() == null) {
+            return List.of();
+        }
+
+        String key = "location:" + event.timestamp();
+
+        GeoOperations<String, String> geoOps = redisTemplate.opsForGeo();
+        GeoResults<RedisGeoCommands.GeoLocation<String>> results =
+                geoOps.radius(key,
+                        new Circle(
+                                new Point(event.longitude(), event.latitude()),
+                                new Distance(radius)
+                        ));
+
+        if (results == null) return List.of();
+
+        return results.getContent().stream()
+                .map(GeoResult::getContent)
+                .map(RedisGeoCommands.GeoLocation::getName)
+                .filter(name -> !name.equals(event.userId()))
+                .toList();
+    }
+}

--- a/src/test/java/com/smooth/alert_service/service/VicinityUserFinderTest.java
+++ b/src/test/java/com/smooth/alert_service/service/VicinityUserFinderTest.java
@@ -1,0 +1,110 @@
+package com.smooth.alert_service.service;
+
+import com.smooth.alert_service.dto.AlertEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.geo.*;
+import org.springframework.data.redis.connection.RedisGeoCommands;
+import org.springframework.data.redis.core.GeoOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class VicinityUserFinderTest {
+
+    @Test
+    void 반경_내_사용자만_조회된다() {
+        // given
+        @SuppressWarnings("unchecked")
+        RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        GeoOperations<String, String> geoOps = mock(GeoOperations.class);
+        when(redisTemplate.opsForGeo()).thenReturn(geoOps);
+
+        var redisResults = List.of(
+                new GeoResult<>(new RedisGeoCommands.GeoLocation<>("alpha", new Point(0, 0)), new Distance(100)),
+                new GeoResult<>(new RedisGeoCommands.GeoLocation<>("bravo", new Point(0, 0)), new Distance(200))
+        );
+        var geoResults = new GeoResults<>(redisResults);
+
+
+        var event = new AlertEvent("accident", "acc-1", "user123", 37.5, 126.9, "20250804121230");
+        var finder = new VicinityUserFinder(redisTemplate);
+
+        when(geoOps.radius(
+                eq("location:" + event.timestamp()),
+                any(Circle.class)
+        )).thenReturn(geoResults);
+
+        // when
+        var result = finder.findNearbyUsers(event);
+
+        // then
+        assertThat(result).containsExactly("alpha", "bravo");
+    }
+
+    @Test
+    void 본인은_제외된다() {
+        // given
+        @SuppressWarnings("unchecked")
+        RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        GeoOperations<String, String> geoOps = mock(GeoOperations.class);
+        when(redisTemplate.opsForGeo()).thenReturn(geoOps);
+
+        var redisResults = List.of(
+                new GeoResult<>(new RedisGeoCommands.GeoLocation<>("user123", new Point(0, 0)), new Distance(50)),
+                new GeoResult<>(new RedisGeoCommands.GeoLocation<>("user999", new Point(0, 0)), new Distance(80))
+        );
+        var geoResults = new GeoResults<>(redisResults);
+
+
+        var event = new AlertEvent("obstacle", null, "user123", 37.5, 126.9, "20250804131010");
+        var finder = new VicinityUserFinder(redisTemplate);
+        when(geoOps.radius(eq("location:" + event.timestamp()), any(Circle.class))).thenReturn(geoResults);
+
+        // when
+        var result = finder.findNearbyUsers(event);
+
+        // then
+        assertThat(result).containsExactly("user999");
+    }
+
+    @Test
+    void 좌표가_null이면_빈_리스트_반환() {
+        // given
+        @SuppressWarnings("unchecked")
+        RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+        var finder = new VicinityUserFinder(redisTemplate);
+
+        var event = new AlertEvent("accident", "acc-1", "user123", null, 126.9, "20250804121230");
+
+        // when
+        var result = finder.findNearbyUsers(event);
+
+        // then
+        assertThat(result).isEmpty();
+        // Redis 호출이 없어야 함
+        verify(redisTemplate, never()).opsForGeo();
+    }
+
+    @Test
+    void 반경이_0인_이벤트는_빈_리스트_반환() {
+        // given
+        @SuppressWarnings("unchecked")
+        RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+        var finder = new VicinityUserFinder(redisTemplate);
+
+        var event = new AlertEvent("start", null, "user123", 37.5, 126.9, "20250804121230");
+
+        // when
+        var result = finder.findNearbyUsers(event);
+
+        // then
+        assertThat(result).isEmpty();
+        // Redis 호출이 없어야 함
+        verify(redisTemplate, never()).opsForGeo();
+    }}


### PR DESCRIPTION
- EventType enum을 정의하여 사고 유형별 반경 조건 설정
  - accident: 300m, obstacle: 100m, pothole: 50m
- Redis GEOSET(location:{timestamp})을 기반으로 사용자 위치 조회
- VicinityUserFinder를 통해 AlertEvent로부터 반경 내 userId 리스트 추출
- 본인(userId) 제외 처리 포함
- 좌표 미지정 또는 반경 0 이벤트(start/end)는 필터링 제외
- RedisTemplate 및 GeoOperations mock 기반 단위 테스트 작성 완료