### PR TITLE
fix: US5.1 - KST 타임스탬프 파싱 적용

### DIFF
--- a/src/main/java/com/smooth/alert_service/core/AlertEventHandler.java
+++ b/src/main/java/com/smooth/alert_service/core/AlertEventHandler.java
@@ -4,6 +4,7 @@ import com.smooth.alert_service.model.AlertType;
 import com.smooth.alert_service.model.AlertEvent;
 import com.smooth.alert_service.model.EventType;
 import com.smooth.alert_service.support.validator.AlertEventValidator;
+import com.smooth.alert_service.support.util.KoreanTimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -89,9 +90,10 @@ public class AlertEventHandler {
 
         Instant refTime;
         try {
-            refTime = Instant.parse(event.timestamp());
+            // 한국시 문자열을 Instant로 변환
+            refTime = KoreanTimeUtil.parseKoreanTime(event.timestamp());
         } catch (Exception e) {
-            log.warn("timestamp 파싱 실패, 현재 시각 사용: {}", event.timestamp());
+            log.warn("한국시 timestamp 파싱 실패, 현재 시각 사용: {}", event.timestamp());
             refTime = Instant.now();
         }
         List<String> targets = vicinityUserFinder.findUsersAround(


### PR DESCRIPTION
## 목적
- 이벤트 timestamp 처리 시 UTC 기반 파싱 문제를 해결
- 한국시(KST) 기준으로 안정적인 파싱을 지원하여 시간 동기화 정확도 향상

---

## 주요 변경 사항
- **AlertEventHandler**
  - `Instant.parse(...)` → `KoreanTimeUtil.parseKoreanTime(...)`로 교체
  - 파싱 실패 시 `Instant.now()`로 대체 처리

---

## BREAKING CHANGE
- 이벤트 timestamp 입력은 반드시 **`"yyyy-MM-dd'T'HH:mm:ss"` (KST 기준)** 이어야 함  
- 기존 UTC 기반의 `"2025-08-04T08:03:00Z"` 같은 형식은 더 이상 지원하지 않음  
- 클라이언트 및 이벤트 생산자는 반드시 **KST 포맷**을 적용해야 함

---

## 참고
- Refs: US5.1