### PR TITLE
PR: T5.2.2 - 성향 조회 모듈 구축 (주간 단건 + 새벽 벌크 워밍) → US5.2 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/DrivecastServiceApplication.java
+++ b/src/main/java/com/smooth/drivecast_service/DrivecastServiceApplication.java
@@ -2,10 +2,12 @@ package com.smooth.drivecast_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableFeignClients
 public class DrivecastServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/smooth/drivecast_service/driving/dto/DrivingCoordinate.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/dto/DrivingCoordinate.java
@@ -3,12 +3,12 @@ package com.smooth.drivecast_service.driving.dto;
 /**
  * 지리적 좌표 DTO
  **/
-public record GeoCoordinate(double latitude, double longitude) {
+public record DrivingCoordinate(double latitude, double longitude) {
 
     /**
      * 유효한 좌표인지 검증하는 생성자
      **/
-    public GeoCoordinate {
+    public DrivingCoordinate {
         if (!isValidLatitude(latitude)) {
             throw new IllegalArgumentException("위도는 -90.0 ~ 90.0 범위여야 합니다: " + latitude);
         }

--- a/src/main/java/com/smooth/drivecast_service/driving/dto/DrivingResponseDto.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/dto/DrivingResponseDto.java
@@ -1,13 +1,13 @@
-package com.smooth.drivecast_service.incident.dto;
+package com.smooth.drivecast_service.driving.dto;
 
 import java.util.Map;
 
 /**
- * 사고 도메인 전용 메시지 DTO
+ * 주행 도메인 전용 메시지 DTO
  * - 출력 전용 DTO (검증된 데이터로 생성)
  * - 클라이언트 응답용
  **/
-public record IncidentMessageDto(
+public record DrivingResponseDto(
         String type,
         Map<String, Object> payload
 ) {}

--- a/src/main/java/com/smooth/drivecast_service/driving/dto/TraitBulkResponseDto.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/dto/TraitBulkResponseDto.java
@@ -1,0 +1,28 @@
+package com.smooth.drivecast_service.driving.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 벌크 성향 조회 응답 DTO
+ * 외부 API 응답: { "data": [...], "generatedAtUtc": "2025-08-26T19:05:00Z" }
+ */
+public record TraitBulkResponseDto(
+        List<TraitResponseDto> data,
+        Instant generatedAtUtc
+) {
+
+    /**
+     * 데이터가 있는지 확인
+     */
+    public boolean hasData() {
+        return data != null && !data.isEmpty();
+    }
+
+    /**
+     * 데이터 개수 반환
+     */
+    public int size() {
+        return data != null ? data.size() : 0;
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/dto/TraitResponseDto.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/dto/TraitResponseDto.java
@@ -1,0 +1,25 @@
+package com.smooth.drivecast_service.driving.dto;
+
+/**
+ * 성향 조회 응답 DTO
+ * 외부 API 응답: { "userId": "31", "character": "dolphin" }
+ */
+public record TraitResponseDto(
+        String userId,
+        String character
+) {
+
+    /**
+     * 성향이 있는지 확인
+     **/
+    public boolean hasCharacter() {
+        return character != null && !character.isBlank();
+    }
+
+    /**
+     * 성향 없음을 나타내는 인스턴스 생성
+     **/
+    public static TraitResponseDto withoutCharacter(String userId) {
+        return new TraitResponseDto(userId, null);
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/exception/DrivingErrorCode.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/exception/DrivingErrorCode.java
@@ -15,10 +15,15 @@ public enum DrivingErrorCode implements ErrorCode {
     INVALID_TIMESTAMP_FORMAT(HttpStatus.BAD_REQUEST, 2004, "타임스탬프 형식이 올바르지 않습니다."),
     INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, 2005, "사용자 ID 형식이 올바르지 않습니다."),
 
-    // 2051~2099: 서버 오류 (매핑/처리/전송 실패)
+    // 2051~2060: 서버 오류 (매핑/처리/전송 실패)
     DRIVING_EVENT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 2051, "주행 이벤트 처리 중 오류가 발생했습니다."),
     DRIVING_MESSAGE_MAPPING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 2052, "주행 메시지 매핑 중 오류가 발생했습니다."),
-    DRIVING_NOTIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 2053, "주행 알림 전송 중 오류가 발생했습니다.");
+    DRIVING_NOTIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 2053, "주행 알림 전송 중 오류가 발생했습니다."),
+
+    // 2061~2079: 성향 관련 오류
+    TRAIT_API_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, 2061, "성향 서비스 연결에 실패했습니다."),
+    TRAIT_BULK_EXPORT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 2062, "성향 벌크 조회에 실패했습니다."),
+    TRAIT_CACHE_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 2063, "성향 캐시 작업에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/smooth/drivecast_service/driving/feign/UserTraitClient.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/feign/UserTraitClient.java
@@ -1,0 +1,30 @@
+package com.smooth.drivecast_service.driving.feign;
+
+import com.smooth.drivecast_service.driving.dto.TraitResponseDto;
+import com.smooth.drivecast_service.driving.dto.TraitBulkResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 유저 서비스 성향 조회 Feign 클라이언트
+ */
+@FeignClient(
+        name = "user-service",
+        url = "${app.client.user-service.url}"
+)
+public interface UserTraitClient {
+
+    /**
+     * 단건 성향 조회
+     */
+    @GetMapping("/internal/v1/traits/{userId}")
+    TraitResponseDto getTrait(@PathVariable String userId);
+
+    /**
+     * 벌크 성향 조회
+     */
+    @GetMapping("/internal/v1/traits/bulk")
+    TraitBulkResponseDto getTraitsBulk(@RequestParam(defaultValue = "true") boolean hasCharacter);
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/feign/test/MockTraitTestController.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/feign/test/MockTraitTestController.java
@@ -1,0 +1,115 @@
+package com.smooth.drivecast_service.driving.feign.test;
+
+import com.smooth.drivecast_service.driving.service.DrivingTraitService;
+import com.smooth.drivecast_service.driving.service.TraitCacheService;
+import com.smooth.drivecast_service.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 성향 서비스 테스트용 컨트롤러
+ * Mock API와 실제 서비스 로직을 테스트
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/test/traits")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "mock.user-service.enabled", havingValue = "true")
+public class MockTraitTestController {
+
+    private final DrivingTraitService drivingTraitService;
+    private final TraitCacheService traitCacheService;
+
+    /**
+     * 단건 성향 조회 테스트
+     */
+    @GetMapping("/single/{userId}")
+    public ApiResponse<Map<String, Object>> testSingleTrait(@PathVariable String userId) {
+        log.info("단건 성향 조회 테스트: userId={}", userId);
+
+        var character = drivingTraitService.getTrait(userId);
+
+        // HashMap으로 명시적 타입 지정
+        Map<String, Object> result = new HashMap<>();
+        result.put("userId", userId);
+        result.put("character", character != null ? character : "없음");
+        result.put("success", character != null);
+
+        return ApiResponse.success("단건 성향 조회 테스트 완료", result);
+    }
+
+    /**
+     * 벌크 성향 조회 테스트
+     */
+    @GetMapping("/bulk")
+    public ApiResponse<Map<String, Object>> testBulkTraits() {
+        log.info("벌크 성향 조회 테스트 시작");
+
+        var traits = drivingTraitService.exportTraits();
+
+        // 샘플 데이터 추출
+        var sampleData = traits.entrySet().stream()
+                .limit(5)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue
+                ));
+
+        // HashMap으로 명시적 타입 지정
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalCount", traits.size());
+        result.put("sampleData", sampleData);
+        result.put("success", !traits.isEmpty());
+
+        return ApiResponse.success("벌크 성향 조회 테스트 완료", result);
+    }
+
+    /**
+     * 다중 사용자 성향 조회 테스트 (캐시 + API)
+     */
+    @PostMapping("/multiple")
+    public ApiResponse<Map<String, Object>> testMultipleTraits(@RequestBody List<String> userIds) {
+        log.info("다중 성향 조회 테스트: userIds={}", userIds);
+
+        var traits = drivingTraitService.getTraitsFromApi(userIds);
+
+        // HashMap으로 명시적 타입 지정
+        Map<String, Object> result = new HashMap<>();
+        result.put("requestedUsers", userIds.size());
+        result.put("foundTraits", traits.size());
+        result.put("traits", traits);
+        result.put("success", true);
+
+        return ApiResponse.success("다중 성향 조회 테스트 완료", result);
+    }
+
+    /**
+     * 캐시 상태 확인
+     */
+    @GetMapping("/cache/stats")
+    public ApiResponse<TraitCacheService.CacheStats> getCacheStats() {
+        log.info("캐시 상태 조회 테스트");
+
+        var stats = traitCacheService.getCacheStats();
+        return ApiResponse.success("캐시 상태 조회 완료", stats);
+    }
+
+    /**
+     * 수동 워밍 캐시 실행
+     */
+    @PostMapping("/cache/warmup")
+    public ApiResponse<String> manualWarmup() {
+        log.info("수동 워밍 캐시 테스트 시작");
+
+        traitCacheService.manualWarmup();
+
+        return ApiResponse.success("수동 워밍 캐시 실행 완료", "워밍 캐시가 실행되었습니다");
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/feign/test/MockUserTraitController.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/feign/test/MockUserTraitController.java
@@ -1,0 +1,106 @@
+package com.smooth.drivecast_service.driving.feign.test;
+
+import com.smooth.drivecast_service.driving.dto.TraitResponseDto;
+import com.smooth.drivecast_service.driving.dto.TraitBulkResponseDto;
+import com.smooth.drivecast_service.global.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * 테스트용 Mock User Trait API
+ * 실제 유저 서비스 API를 시뮬레이션
+ *
+ * 활성화: application.yml에 mock.user-service.enabled=true 설정
+ */
+@Slf4j
+@RestController
+@RequestMapping("/internal/v1/traits")
+@ConditionalOnProperty(name = "mock.user-service.enabled", havingValue = "true")
+public class MockUserTraitController {
+
+    private static final String[] CHARACTERS = {"dolphin", "lion", "eagle", "bear", "fox", "rabbit"};
+    private static final Random random = new Random();
+
+    /**
+     * 단건 성향 조회 Mock API
+     * GET /internal/v1/traits/{userId}
+     */
+    @GetMapping("/{userId}")
+    public TraitResponseDto getTrait(@PathVariable String userId) {
+        log.info("Mock API 호출: 단건 성향 조회 - userId={}", userId);
+
+        // 시뮬레이션: 일부 사용자는 404 (성향 없음)
+        if (userId.endsWith("99") || userId.endsWith("00")) {
+            log.info("Mock API: 성향 없음 시뮬레이션 - userId={}", userId);
+            throw new MockNotFoundException("성향을 찾을 수 없습니다");
+        }
+
+        // 시뮬레이션: 일부 사용자는 5xx 에러
+        if (userId.endsWith("88")) {
+            log.error("Mock API: 서버 오류 시뮬레이션 - userId={}", userId);
+            throw new MockServerException("서버 내부 오류");
+        }
+
+        // 정상 응답: 랜덤 성향 반환
+        String character = CHARACTERS[random.nextInt(CHARACTERS.length)];
+        var response = new TraitResponseDto(userId, character);
+
+        log.info("Mock API 응답: userId={}, character={}", userId, character);
+        return response;
+    }
+
+    /**
+     * 벌크 성향 조회 Mock API
+     * GET /internal/v1/traits/bulk?hasCharacter=true
+     */
+    @GetMapping("/bulk")
+    public TraitBulkResponseDto getTraitsBulk(@RequestParam(defaultValue = "true") boolean hasCharacter) {
+        log.info("Mock API 호출: 벌크 성향 조회 - hasCharacter={}", hasCharacter);
+
+        // 시뮬레이션: 100명의 사용자 데이터 생성
+        var mockData = generateMockBulkData(100);
+        var response = new TraitBulkResponseDto(mockData, Instant.now());
+
+        log.info("Mock API 응답: 벌크 데이터 {}명 생성", mockData.size());
+        return response;
+    }
+
+    /**
+     * Mock 벌크 데이터 생성
+     */
+    private List<TraitResponseDto> generateMockBulkData(int count) {
+        return java.util.stream.IntStream.range(1, count + 1)
+                .mapToObj(i -> {
+                    String userId = String.valueOf(1000 + i);
+                    String character = CHARACTERS[random.nextInt(CHARACTERS.length)];
+                    return new TraitResponseDto(userId, character);
+                })
+                .toList();
+    }
+
+    /**
+     * Mock 404 예외
+     */
+    @ResponseStatus(org.springframework.http.HttpStatus.NOT_FOUND)
+    public static class MockNotFoundException extends RuntimeException {
+        public MockNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Mock 500 예외
+     */
+    @ResponseStatus(org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR)
+    public static class MockServerException extends RuntimeException {
+        public MockServerException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/service/DrivingTraitService.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/DrivingTraitService.java
@@ -1,0 +1,147 @@
+package com.smooth.drivecast_service.driving.service;
+
+import com.smooth.drivecast_service.driving.exception.DrivingErrorCode;
+import com.smooth.drivecast_service.driving.feign.UserTraitClient;
+import com.smooth.drivecast_service.global.exception.BusinessException;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 성향 API 서비스
+ * 외부 API 호출 및 예외 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrivingTraitService {
+
+    private final UserTraitClient userTraitClient;
+
+    // 유효한 성향 enum 값들 (검증용)
+    private static final Set<String> VALID_CHARACTERS = Set.of(
+            "dolphin", "lion", "meerkat", "cat"
+    );
+
+    /**
+     * 벌크 성향 조회 (워밍 캐시용)
+     */
+    public Map<String, String> exportTraits() {
+        try {
+            var response = userTraitClient.getTraitsBulk(true);
+
+            if (response == null || !response.hasData()) {
+                log.warn("벌크 성향 조회 결과 없음");
+                return Map.of();
+            }
+
+            var result = new HashMap<String, String>();
+            response.data().forEach(trait -> {
+                if (trait.hasCharacter() && isValidCharacter(trait.character())) {
+                    result.put(trait.userId(), trait.character());
+                } else if (trait.hasCharacter()) {
+                    log.warn("유효하지 않은 성향 값: userId={}, character={}",
+                            trait.userId(), trait.character());
+                }
+            });
+
+            log.info("벌크 성향 조회 완료: 전체={}명, 유효={}명, 생성시각={}",
+                    response.data().size(), result.size(), response.generatedAtUtc());
+            return result;
+
+        } catch (FeignException.NotFound e) {
+            log.warn("벌크 성향 API 404: {}", e.getMessage());
+            return Map.of();
+
+        } catch (FeignException e) {
+            if (e.status() >= 500) {
+                log.error("벌크 성향 API 서버 오류: status={}, 메시지={}", e.status(), e.getMessage());
+                throw new BusinessException(DrivingErrorCode.TRAIT_BULK_EXPORT_FAILED,
+                        "벌크 성향 조회 서버 오류: " + e.status());
+            } else {
+                log.warn("벌크 성향 API 클라이언트 오류: status={}, 메시지={}", e.status(), e.getMessage());
+                return Map.of();
+            }
+
+        } catch (Exception e) {
+            log.error("벌크 성향 조회 예외", e);
+            throw new BusinessException(DrivingErrorCode.TRAIT_BULK_EXPORT_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * 단건 성향 조회 (실시간 폴백용)
+     */
+    public String getTrait(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return null;
+        }
+
+        try {
+            var response = userTraitClient.getTrait(userId);
+
+            if (response != null && response.hasCharacter()) {
+                if (isValidCharacter(response.character())) {
+                    log.debug("단건 성향 조회 성공: userId={}, character={}", userId, response.character());
+                    return response.character();
+                } else {
+                    log.warn("유효하지 않은 성향 값: userId={}, character={}", userId, response.character());
+                    return null;
+                }
+            }
+
+            log.debug("성향 없음: userId={}", userId);
+            return null;
+
+        } catch (FeignException.NotFound e) {
+            log.debug("성향 없음 (404): userId={}", userId);
+            return null;
+
+        } catch (FeignException e) {
+            if (e.status() >= 500) {
+                log.warn("단건 성향 API 서버 오류: userId={}, status={}", userId, e.status());
+            } else {
+                log.debug("단건 성향 API 클라이언트 오류: userId={}, status={}", userId, e.status());
+            }
+            return null;
+
+        } catch (Exception e) {
+            log.warn("단건 성향 조회 예외: userId={}, 오류={}", userId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 여러 사용자 성향 조회 (순수 API 호출만)
+     */
+    public Map<String, String> getTraitsFromApi(List<String> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        var result = new HashMap<String, String>();
+
+        for (String userId : userIds) {
+            var character = getTrait(userId);
+            if (character != null) {
+                result.put(userId, character);
+            }
+        }
+
+        log.debug("API 성향 조회 완료: 요청={}명, 조회={}명", userIds.size(), result.size());
+        return result;
+    }
+
+    /**
+     * 성향 값 유효성 검증
+     */
+    private boolean isValidCharacter(String character) {
+        return character != null && VALID_CHARACTERS.contains(character.toLowerCase());
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/service/mapper/DrivingMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/mapper/DrivingMessageMapper.java
@@ -1,6 +1,6 @@
 package com.smooth.drivecast_service.driving.service.mapper;
 
-import com.smooth.drivecast_service.driving.dto.DrivingMessageDto;
+import com.smooth.drivecast_service.driving.dto.DrivingResponseDto;
 
 import java.util.Optional;
 
@@ -22,5 +22,5 @@ public interface DrivingMessageMapper {
      * @param context 매핑 컨텍스트
      * @return 변환된 AlertMessageDto, 실패시 empty
      **/
-    Optional<DrivingMessageDto> map(DrivingMappingContext context);
+    Optional<DrivingResponseDto> map(DrivingMappingContext context);
 }

--- a/src/main/java/com/smooth/drivecast_service/driving/service/mapper/EndMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/mapper/EndMessageMapper.java
@@ -1,6 +1,6 @@
 package com.smooth.drivecast_service.driving.service.mapper;
 
-import com.smooth.drivecast_service.driving.dto.DrivingMessageDto;
+import com.smooth.drivecast_service.driving.dto.DrivingResponseDto;
 import com.smooth.drivecast_service.driving.exception.DrivingErrorCode;
 import com.smooth.drivecast_service.global.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +19,11 @@ public class EndMessageMapper implements  DrivingMessageMapper{
     }
 
     @Override
-    public Optional<DrivingMessageDto> map(DrivingMappingContext context) {
+    public Optional<DrivingResponseDto> map(DrivingMappingContext context) {
         try {
             var event = context.getEvent();
 
-            return Optional.of(new DrivingMessageDto(
+            return Optional.of(new DrivingResponseDto(
                     "end",
                     Map.of(
                             "timestamp", event.timestamp()

--- a/src/main/java/com/smooth/drivecast_service/driving/service/mapper/StartMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/mapper/StartMessageMapper.java
@@ -1,6 +1,6 @@
 package com.smooth.drivecast_service.driving.service.mapper;
 
-import com.smooth.drivecast_service.driving.dto.DrivingMessageDto;
+import com.smooth.drivecast_service.driving.dto.DrivingResponseDto;
 import com.smooth.drivecast_service.driving.exception.DrivingErrorCode;
 import com.smooth.drivecast_service.global.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +19,11 @@ public class StartMessageMapper implements  DrivingMessageMapper{
     }
 
     @Override
-    public Optional<DrivingMessageDto> map(DrivingMappingContext context) {
+    public Optional<DrivingResponseDto> map(DrivingMappingContext context) {
         try {
             var event = context.getEvent();
 
-            return Optional.of(new DrivingMessageDto(
+            return Optional.of(new DrivingResponseDto(
                     "start",
                     Map.of(
                             "timestamp", event.timestamp()

--- a/src/main/java/com/smooth/drivecast_service/global/common/location/WindowGeoSearchAdapter.java
+++ b/src/main/java/com/smooth/drivecast_service/global/common/location/WindowGeoSearchAdapter.java
@@ -1,6 +1,6 @@
 package com.smooth.drivecast_service.global.common.location;
 
-import com.smooth.drivecast_service.driving.dto.GeoCoordinate;
+import com.smooth.drivecast_service.driving.dto.DrivingCoordinate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,7 +29,7 @@ public class WindowGeoSearchAdapter {
     /**
      * 여러 키에서 반경 검색 후 합집합 반환
      **/
-    public Set<String> searchAcrossKeys(List<String> locationKeys, GeoCoordinate center, int radiusMeters) {
+    public Set<String> searchAcrossKeys(List<String> locationKeys, DrivingCoordinate center, int radiusMeters) {
         if (locationKeys == null || locationKeys.isEmpty() || center == null) {
             return Set.of();
         }
@@ -51,7 +51,7 @@ public class WindowGeoSearchAdapter {
         return allUsers;
     }
 
-    private Set<String> searchInKey(String locationKey, GeoCoordinate center, int radiusMeters) {
+    private Set<String> searchInKey(String locationKey, DrivingCoordinate center, int radiusMeters) {
         Set<String> users = new HashSet<>();
 
         try {

--- a/src/main/java/com/smooth/drivecast_service/global/common/location/WindowLocationAdapter.java
+++ b/src/main/java/com/smooth/drivecast_service/global/common/location/WindowLocationAdapter.java
@@ -1,6 +1,6 @@
 package com.smooth.drivecast_service.global.common.location;
 
-import com.smooth.drivecast_service.driving.dto.GeoCoordinate;
+import com.smooth.drivecast_service.driving.dto.DrivingCoordinate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,7 +25,7 @@ public class WindowLocationAdapter {
     /**
      * 여러 키에서 사용자 위치 조회
      **/
-    public Optional<GeoCoordinate> findUserLocation(List<String> locationKeys, String userId) {
+    public Optional<DrivingCoordinate> findUserLocation(List<String> locationKeys, String userId) {
         if (locationKeys == null || locationKeys.isEmpty() || userId == null) {
             return Optional.empty();
         }
@@ -36,7 +36,7 @@ public class WindowLocationAdapter {
 
                 if (positions != null && !positions.isEmpty() && positions.getFirst() != null) {
                     var point = positions.getFirst();
-                    var coordinate = new GeoCoordinate(point.getY(), point.getX());
+                    var coordinate = new DrivingCoordinate(point.getY(), point.getX());
 
                     log.debug("사용자 위치 발견: userId={}, key={}, 좌표={}", userId, key, coordinate);
                     return Optional.of(coordinate);

--- a/src/main/java/com/smooth/drivecast_service/incident/dto/IncidentResponseDto.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/dto/IncidentResponseDto.java
@@ -1,13 +1,13 @@
-package com.smooth.drivecast_service.driving.dto;
+package com.smooth.drivecast_service.incident.dto;
 
 import java.util.Map;
 
 /**
- * 주행 도메인 전용 메시지 DTO
+ * 사고 도메인 전용 메시지 DTO
  * - 출력 전용 DTO (검증된 데이터로 생성)
  * - 클라이언트 응답용
  **/
-public record DrivingMessageDto(
+public record IncidentResponseDto(
         String type,
         Map<String, Object> payload
 ) {}

--- a/src/main/java/com/smooth/drivecast_service/incident/service/mapper/AccidentMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/service/mapper/AccidentMessageMapper.java
@@ -1,7 +1,7 @@
 package com.smooth.drivecast_service.incident.service.mapper;
 
 import com.smooth.drivecast_service.global.exception.BusinessException;
-import com.smooth.drivecast_service.incident.dto.IncidentMessageDto;
+import com.smooth.drivecast_service.incident.dto.IncidentResponseDto;
 import com.smooth.drivecast_service.incident.exception.IncidentErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,10 +19,10 @@ public class AccidentMessageMapper implements  IncidentMessageMapper{
     }
 
     @Override
-    public Optional<IncidentMessageDto> map(IncidentMappingContext context) {
+    public Optional<IncidentResponseDto> map(IncidentMappingContext context) {
         try {
             if (context.isSelfIncident()) {
-                return Optional.of(new IncidentMessageDto(
+                return Optional.of(new IncidentResponseDto(
                         "accident",
                         Map.of(
                                 "title", "큰 사고가 발생했습니다!",
@@ -30,7 +30,7 @@ public class AccidentMessageMapper implements  IncidentMessageMapper{
                         )
                 ));
             } else {
-                return Optional.of(new IncidentMessageDto(
+                return Optional.of(new IncidentResponseDto(
                         "accident-nearby",
                         Map.of(
                                 "title", "전방 사고 발생!",

--- a/src/main/java/com/smooth/drivecast_service/incident/service/mapper/IncidentMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/service/mapper/IncidentMessageMapper.java
@@ -1,6 +1,6 @@
 package com.smooth.drivecast_service.incident.service.mapper;
 
-import com.smooth.drivecast_service.incident.dto.IncidentMessageDto;
+import com.smooth.drivecast_service.incident.dto.IncidentResponseDto;
 
 import java.util.Optional;
 
@@ -22,7 +22,7 @@ public interface IncidentMessageMapper {
      * @param context 매핑 컨텍스트
      * @return 변환된 AlertMessageDto, 실패시 empty
      **/
-    Optional<IncidentMessageDto> map(IncidentMappingContext context);
+    Optional<IncidentResponseDto> map(IncidentMappingContext context);
 
     /**
      * 사고 이벤트를 특정 사용자용 알림 메시지로 변환
@@ -30,7 +30,7 @@ public interface IncidentMessageMapper {
      * @param targetUserId 대상 사용자 ID
      * @return 변환된 AlertMessageDto, 실패시 empty
      **/
-    default Optional<IncidentMessageDto> map(IncidentMappingContext context, String targetUserId) {
+    default Optional<IncidentResponseDto> map(IncidentMappingContext context, String targetUserId) {
         var contextWithUser = IncidentMappingContext.of(context.getEvent(), targetUserId);
         return map(contextWithUser);
     }

--- a/src/main/java/com/smooth/drivecast_service/incident/service/mapper/ObstacleMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/service/mapper/ObstacleMessageMapper.java
@@ -1,7 +1,7 @@
 package com.smooth.drivecast_service.incident.service.mapper;
 
 import com.smooth.drivecast_service.global.exception.BusinessException;
-import com.smooth.drivecast_service.incident.dto.IncidentMessageDto;
+import com.smooth.drivecast_service.incident.dto.IncidentResponseDto;
 import com.smooth.drivecast_service.incident.exception.IncidentErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,11 +19,11 @@ public class ObstacleMessageMapper implements IncidentMessageMapper {
     }
 
     @Override
-    public Optional<IncidentMessageDto> map(IncidentMappingContext context) {
+    public Optional<IncidentResponseDto> map(IncidentMappingContext context) {
         try {
             var event = context.getEvent();
 
-            return Optional.of(new IncidentMessageDto(
+            return Optional.of(new IncidentResponseDto(
                     "obstacle",
                     Map.of(
                             "title", "전방 장애물 발견",


### PR DESCRIPTION
# PR: T5.2.2 - 성향 조회 모듈 구축 (주간 단건 + 새벽 벌크 워밍) → US5.2 머지

## 목적
- 운전자 성향 데이터를 효율적으로 제공하기 위해 Redis 캐시(HOT/WARM) 계층을 도입
- 캐시 미스 시 외부 UserTrait API를 연동
- 캐시 TTL 및 워밍 스케줄링을 적용하여 API 호출 부담을 줄이고 조회 안정성을 확보

---

## 구현/변경 사항
- **추가**
  - `DrivingTraitService`: 외부 UserTrait API 연동 (단건/벌크 조회, 예외 처리)
  - `UserTraitClient`: Feign 기반 API 클라이언트
  - DTO: `TraitResponseDto`, `TraitBulkResponseDto`
  - 테스트 지원: `MockUserTraitController`, `MockTraitTestController`
- **변경**
  - `TraitCacheService`: 캐시 조회/저장 + API 폴백 로직 구현, 새벽 워밍 시 API 연동
  - `DrivecastServiceApplication`: `@EnableFeignClients` 추가
  - `DrivingErrorCode`: 성향 관련 오류 코드 확장
  - DTO/매퍼 네이밍 개선 (`GeoCoordinate` → `DrivingCoordinate`, `MessageDto` → `ResponseDto`)

---

## 테스트
- **환경**: 로컬 Redis + Mock API (`mock.user-service.enabled=true`)
- **방법**:
  - 단건/벌크 성향 조회 테스트 API 호출
  - 캐시 HIT/MISS 시나리오 검증
  - 새벽 워밍 스케줄러 실행 로그 확인
- **결과**:
  - 캐시 적중/만료/폴백 동작 정상
  - Mock API를 통한 단건/벌크 조회 및 캐시 저장 확인

---

## 참고
- **관련 이슈/유저 스토리**: Refs: #3 / #15
- 후속 작업: 운영 환경에서 실제 UserTrait API URL 연동 필요