### PR TITLE
PR: T5.2.2 - 실시간 STOMP 전송 로직 구현 → US5.2 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/driving/constants/DrivingVicinityPolicy.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/constants/DrivingVicinityPolicy.java
@@ -20,6 +20,9 @@ public class DrivingVicinityPolicy {
     public static final String TRAIT_HOT_PREFIX = "trait:";
     public static final String TRAIT_WARM_PREFIX = "trait:warm:";
     public static final String DRIVING_ACTIVE_SET = "driving:active";
+    
+    // 활성 세트 TTL (초)
+    public static final int ACTIVE_SET_TTL_SEC = 60 * 60; // 1시간
 
     private DrivingVicinityPolicy() {}
 }

--- a/src/main/java/com/smooth/drivecast_service/driving/service/DrivingBroadcastScheduler.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/DrivingBroadcastScheduler.java
@@ -1,0 +1,204 @@
+package com.smooth.drivecast_service.driving.service;
+
+import com.smooth.drivecast_service.driving.constants.DrivingDestinations;
+import com.smooth.drivecast_service.driving.dto.DrivingResponseDto;
+import com.smooth.drivecast_service.global.common.notification.RealtimePublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 주행 근접 운전자 성향 실시간 브로드캐스트 스케줄러
+ * 1Hz 주기로 활성 사용자들에게 주변 운전자 성향 정보 전송
+ **/
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrivingBroadcastScheduler {
+
+    private final RealtimePublisher realtimePublisher;
+    private final DrivingSessionManager sessionManager;
+    private final DrivingVicinityService vicinityService;
+    private final TraitCacheService traitCacheService;
+    private final DrivingCoordinateService coordinateService;
+
+    /**
+     * 1초마다 주변 운전자 성향 브로드캐스트
+     **/
+    @Scheduled(fixedRate = 1000) // 1Hz = 1000ms
+    public void broadcastNearbyTraits() {
+        var startTime = System.currentTimeMillis();
+        
+        try {
+            var activeUsers = sessionManager.getActiveUsers();
+            if (activeUsers.isEmpty()) {
+                return; // 활성 사용자 없음
+            }
+
+            var processedCount = 0;
+            var totalNearbyCount = 0;
+
+            for (String userId : activeUsers) {
+                try {
+                    var vicinityData = processUserVicinityData(userId);
+                    if (vicinityData != null) {
+                        sendVicinityDataToUser(userId, vicinityData);
+                        processedCount++;
+                        totalNearbyCount += vicinityData.neighbors().size();
+                    }
+                } catch (Exception e) {
+                    log.warn("사용자 성향 브로드캐스트 실패: userId={}, 오류={}", userId, e.getMessage());
+                }
+            }
+
+            var elapsed = System.currentTimeMillis() - startTime;
+            if (processedCount > 0) {
+                log.debug("성향 브로드캐스트 완료: 활성={}명, 처리={}명, 주변={}명, 소요={}ms", 
+                        activeUsers.size(), processedCount, totalNearbyCount, elapsed);
+            }
+
+        } catch (Exception e) {
+            log.error("성향 브로드캐스트 스케줄러 오류", e);
+        }
+    }
+
+    /**
+     * 사용자 주변 운전자 데이터 처리
+     **/
+    private VicinityData processUserVicinityData(String userId) {
+        try {
+            // 1. ego 위치 조회
+            var egoCoordinate = coordinateService.getUserCoordinate(userId);
+            if (egoCoordinate.isEmpty()) {
+                log.debug("ego 위치 없음: userId={}", userId);
+                return null;
+            }
+
+            // 2. 주변 운전자 탐지
+            var nearbyDrivers = vicinityService.findNearbyDrivers(userId);
+            if (nearbyDrivers.isEmpty()) {
+                // 주변 운전자가 없어도 ego 정보는 전송
+                return new VicinityData(
+                    new EgoData(userId, egoCoordinate.get()),
+                    List.of()
+                );
+            }
+
+            // 3. 주변 운전자 좌표 조회
+            var nearbyCoordinates = coordinateService.getUserCoordinates(nearbyDrivers);
+
+            // 4. 성향 조회 (캐시 우선)
+            var traits = traitCacheService.getTraitsForUsers(nearbyDrivers);
+
+            // 5. 이웃 데이터 생성 (좌표와 성향이 모두 있는 경우만)
+            var neighbors = nearbyDrivers.stream()
+                    .filter(nearbyCoordinates::containsKey)
+                    .filter(traits::containsKey)
+                    .map(neighborId -> new NeighborData(
+                            neighborId,
+                            traits.get(neighborId),
+                            nearbyCoordinates.get(neighborId)
+                    ))
+                    .toList();
+            
+            log.debug("사용자 주변 데이터 처리: ego={}, 주변={}명, 완성={}명", 
+                    userId, nearbyDrivers.size(), neighbors.size());
+            
+            return new VicinityData(
+                new EgoData(userId, egoCoordinate.get()),
+                neighbors
+            );
+
+        } catch (Exception e) {
+            log.warn("사용자 주변 데이터 처리 실패: userId={}, 오류={}", userId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 사용자에게 주변 데이터 전송
+     **/
+    private void sendVicinityDataToUser(String userId, VicinityData vicinityData) {
+        try {
+            // 기존 DrivingResponseDto 활용
+            var payload = createVicinityPayload(vicinityData);
+            var response = new DrivingResponseDto("driving", payload);
+            
+            // RealtimePublisher를 통해 전송 (기존 패턴과 동일)
+            realtimePublisher.toUser(userId, DrivingDestinations.DRIVING_STATUS, response);
+            
+            log.debug("주변 데이터 전송 완료: userId={}, 이웃={}명", userId, vicinityData.neighbors().size());
+
+        } catch (Exception e) {
+            log.warn("주변 데이터 전송 실패: userId={}, 오류={}", userId, e.getMessage());
+        }
+    }
+
+    /**
+     * 주변 데이터 페이로드 생성
+     **/
+    private Map<String, Object> createVicinityPayload(VicinityData vicinityData) {
+        var payload = new HashMap<String, Object>();
+        
+        // timestamp (ISO 8601 형식)
+        payload.put("timestamp", java.time.Instant.now().toString());
+        
+        // ego 데이터
+        var egoMap = Map.of(
+                "userId", vicinityData.ego().userId(),
+                "pose", Map.of(
+                        "latitude", vicinityData.ego().coordinate().latitude(),
+                        "longitude", vicinityData.ego().coordinate().longitude()
+                )
+        );
+        payload.put("ego", egoMap);
+        
+        // neighbors 데이터
+        var neighborsList = vicinityData.neighbors().stream()
+                .map(neighbor -> Map.of(
+                        "userId", neighbor.userId(),
+                        "character", neighbor.character(),
+                        "pose", Map.of(
+                                "latitude", neighbor.coordinate().latitude(),
+                                "longitude", neighbor.coordinate().longitude()
+                        )
+                ))
+                .toList();
+        payload.put("neighbors", neighborsList);
+        
+        return payload;
+    }
+
+    /**
+     * 브로드캐스트 통계 조회
+     **/
+    public BroadcastStats getStats() {
+        var activeCount = sessionManager.getActiveUserCount();
+        return new BroadcastStats(activeCount);
+    }
+
+    /**
+     * 브로드캐스트 통계 정보
+     **/
+    public record BroadcastStats(long activeUserCount) {}
+
+    /**
+     * 주변 데이터 전체 정보
+     **/
+    private record VicinityData(EgoData ego, java.util.List<NeighborData> neighbors) {}
+
+    /**
+     * Ego 사용자 데이터
+     **/
+    private record EgoData(String userId, com.smooth.drivecast_service.driving.dto.DrivingCoordinate coordinate) {}
+
+    /**
+     * 이웃 사용자 데이터
+     **/
+    private record NeighborData(String userId, String character, com.smooth.drivecast_service.driving.dto.DrivingCoordinate coordinate) {}
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/service/DrivingCoordinateService.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/DrivingCoordinateService.java
@@ -1,0 +1,111 @@
+package com.smooth.drivecast_service.driving.service;
+
+import com.smooth.drivecast_service.driving.dto.DrivingCoordinate;
+import com.smooth.drivecast_service.driving.util.LocationWindowKeyGenerator;
+import com.smooth.drivecast_service.global.common.location.WindowLocationAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 주행 좌표 조회 서비스
+ * 사용자들의 현재 위치 정보 제공
+ **/
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrivingCoordinateService {
+
+    private final WindowLocationAdapter windowLocationAdapter;
+
+    /**
+     * 단일 사용자 좌표 조회
+     **/
+    public Optional<DrivingCoordinate> getUserCoordinate(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            var windowKeys = LocationWindowKeyGenerator.generateDefaultWindowKeys(Instant.now());
+            var location = windowLocationAdapter.findUserLocation(windowKeys, userId);
+            
+            if (location.isPresent()) {
+                var coord = location.get();
+                log.debug("사용자 좌표 조회 성공: userId={}, lat={}, lng={}", 
+                        userId, coord.latitude(), coord.longitude());
+                return Optional.of(coord);
+            }
+            
+            log.debug("사용자 좌표 없음: userId={}", userId);
+            return Optional.empty();
+            
+        } catch (Exception e) {
+            log.warn("사용자 좌표 조회 실패: userId={}, 오류={}", userId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 여러 사용자 좌표 일괄 조회
+     **/
+    public Map<String, DrivingCoordinate> getUserCoordinates(List<String> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        var result = new HashMap<String, DrivingCoordinate>();
+        var windowKeys = LocationWindowKeyGenerator.generateDefaultWindowKeys(Instant.now());
+
+        for (String userId : userIds) {
+            try {
+                var location = windowLocationAdapter.findUserLocation(windowKeys, userId);
+                if (location.isPresent()) {
+                    result.put(userId, location.get());
+                }
+            } catch (Exception e) {
+                log.warn("사용자 좌표 조회 실패: userId={}, 오류={}", userId, e.getMessage());
+            }
+        }
+
+        log.debug("좌표 일괄 조회 완료: 요청={}명, 조회={}명", userIds.size(), result.size());
+        return result;
+    }
+
+    /**
+     * 사용자 위치 존재 여부 확인
+     **/
+    public boolean hasUserLocation(String userId) {
+        return getUserCoordinate(userId).isPresent();
+    }
+
+    /**
+     * 여러 사용자 위치 존재 여부 확인
+     **/
+    public Map<String, Boolean> checkUserLocations(List<String> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        var result = new HashMap<String, Boolean>();
+        var windowKeys = LocationWindowKeyGenerator.generateDefaultWindowKeys(Instant.now());
+
+        for (String userId : userIds) {
+            try {
+                var hasLocation = windowLocationAdapter.findUserLocation(windowKeys, userId).isPresent();
+                result.put(userId, hasLocation);
+            } catch (Exception e) {
+                log.warn("사용자 위치 확인 실패: userId={}, 오류={}", userId, e.getMessage());
+                result.put(userId, false);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/driving/service/DrivingSessionManager.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/DrivingSessionManager.java
@@ -1,0 +1,114 @@
+package com.smooth.drivecast_service.driving.service;
+
+import com.smooth.drivecast_service.driving.constants.DrivingVicinityPolicy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 주행 활성 세션 관리 서비스
+ * 브로드캐스트 대상 사용자 세트 관리
+ **/
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrivingSessionManager {
+
+    @Qualifier("stringRedisTemplate")
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * 활성 세트에 사용자 추가
+     **/
+    public void addActiveUser(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.opsForSet().add(DrivingVicinityPolicy.DRIVING_ACTIVE_SET, userId);
+            stringRedisTemplate.expire(DrivingVicinityPolicy.DRIVING_ACTIVE_SET, 
+                    DrivingVicinityPolicy.ACTIVE_SET_TTL_SEC, TimeUnit.SECONDS);
+            
+            log.debug("활성 세트 추가: userId={}", userId);
+        } catch (Exception e) {
+            log.warn("활성 세트 추가 실패: userId={}, 오류={}", userId, e.getMessage());
+        }
+    }
+
+    /**
+     * 활성 세트에서 사용자 제거
+     **/
+    public void removeActiveUser(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.opsForSet().remove(DrivingVicinityPolicy.DRIVING_ACTIVE_SET, userId);
+            log.debug("활성 세트 제거: userId={}", userId);
+        } catch (Exception e) {
+            log.warn("활성 세트 제거 실패: userId={}, 오류={}", userId, e.getMessage());
+        }
+    }
+
+    /**
+     * 모든 활성 사용자 조회
+     **/
+    public Set<String> getActiveUsers() {
+        try {
+            var activeUsers = stringRedisTemplate.opsForSet().members(DrivingVicinityPolicy.DRIVING_ACTIVE_SET);
+            return activeUsers != null ? activeUsers : Set.of();
+        } catch (Exception e) {
+            log.warn("활성 세트 조회 실패: {}", e.getMessage());
+            return Set.of();
+        }
+    }
+
+    /**
+     * 활성 사용자 수 조회
+     **/
+    public long getActiveUserCount() {
+        try {
+            var count = stringRedisTemplate.opsForSet().size(DrivingVicinityPolicy.DRIVING_ACTIVE_SET);
+            return count != null ? count : 0L;
+        } catch (Exception e) {
+            log.warn("활성 세트 크기 조회 실패: {}", e.getMessage());
+            return 0L;
+        }
+    }
+
+    /**
+     * 사용자가 활성 상태인지 확인
+     **/
+    public boolean isActiveUser(String userId) {
+        if (userId == null || userId.isBlank()) {
+            return false;
+        }
+
+        try {
+            var isActive = stringRedisTemplate.opsForSet().isMember(DrivingVicinityPolicy.DRIVING_ACTIVE_SET, userId);
+            return isActive != null && isActive;
+        } catch (Exception e) {
+            log.warn("활성 상태 확인 실패: userId={}, 오류={}", userId, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 활성 세트 초기화 (운영/테스트용)
+     **/
+    public void clearActiveUsers() {
+        try {
+            stringRedisTemplate.delete(DrivingVicinityPolicy.DRIVING_ACTIVE_SET);
+            log.info("활성 세트 초기화 완료");
+        } catch (Exception e) {
+            log.warn("활성 세트 초기화 실패: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# PR: T5.2.2 - 실시간 STOMP 전송 로직 구현 → US5.2 머지

## 목적
- 주행 중 활성 사용자를 Redis 기반으로 관리하고, 1Hz 주기로 주변 운전자 성향 데이터를 브로드캐스트
- 실시간 주행 화면에서 안정적인 성향/위치 정보를 제공하여 사용자 경험을 개선

---

## 구현/변경 사항
- **추가**
  - `DrivingSessionManager`: Redis Set 기반 활성 사용자 세션 관리 (추가/제거/조회/검증/초기화)
  - `DrivingCoordinateService`: 사용자 좌표 단건/다중 조회 및 위치 존재 여부 확인
  - `DrivingBroadcastScheduler`: 1Hz 주기로 활성 사용자에게 주변 운전자 성향 데이터 전송
- **변경**
  - `DrivingEventHandler`: START/END 이벤트 발생 시 활성 세션 업데이트
  - `DrivingVicinityPolicy`: 활성 세션 TTL(1시간) 상수 추가

---

## 테스트
- **환경**: 로컬 Redis, Docker 환경
- **방법**:
  - START 이벤트 → 활성 세션 추가 확인
  - END 이벤트 → 활성 세션 제거 확인
  - 활성 사용자 존재 시 1Hz 브로드캐스트 발생 로그 검증
  - ego 좌표 없음/이웃 없음 → 안전히 스킵 처리 확인
- **결과**:
  - 세션 갱신 및 TTL 만료 정상 동작
  - payload 구조 `{timestamp, ego, neighbors}` 정상 전송 확인

---

## 참고
- **관련 이슈/유저 스토리**: Refs: #3 / #16 