### PR TITLE
PR: T5.3.2 <응급 문자 전송 로직> → US5.3 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	// Jackson (추가적 안정성용)
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	// Twilio SMS
+    implementation 'com.twilio.sdk:twilio:10.6.3'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/smooth/drivecast_service/emergency/service/SmsService.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/service/SmsService.java
@@ -1,0 +1,85 @@
+package com.smooth.drivecast_service.emergency.service;
+
+import com.smooth.drivecast_service.global.config.TwilioConfig;
+import com.smooth.drivecast_service.emergency.dto.EmergencyUserInfoDto;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+    
+    private final TwilioConfig twilioConfig;
+    
+    @Value("${TWILIO_TEST_NUMBER}")
+    private String testPhoneNumber;
+    
+    public boolean send119(String message) {
+        log.info("SMS 발송 시도 - testPhoneNumber: {}", testPhoneNumber);
+        try {
+            Message twilioMessage = Message.creator(
+                new PhoneNumber(testPhoneNumber), 
+                new PhoneNumber(twilioConfig.getPhoneNumber()),
+                "[Emergency 119] " + message
+            ).create();
+            
+            log.info("119 SMS 발송 성공 - SID: {}, To: {}", twilioMessage.getSid(), testPhoneNumber);
+            return true;
+        } catch (Exception e) {
+            log.error("119 SMS 발송 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+    
+    public boolean sendFamily(EmergencyUserInfoDto userInfo, String message) {
+        log.info("가족 SMS 발송 시작 - 유저ID: {}", userInfo.getUserId());
+        boolean allSent = true;
+        
+        if (userInfo.getEmergencyContact1() != null && !userInfo.getEmergencyContact1().trim().isEmpty()) {
+            // 테스트용으로 모든 가족 연락처는 testPhoneNumber로 발송
+            // String convertedNumber = convertToInternationalFormat(userInfo.getEmergencyContact1());
+            // allSent &= sendSingleSms(convertedNumber, "[Family Emergency 1] " + message);
+            allSent &= sendSingleSms(testPhoneNumber, "[Family Emergency 1] " + message);
+            log.info("가족1에게 SMS 발송 완료: {} -> {}", userInfo.getEmergencyContact1(), testPhoneNumber);
+        }
+        
+        if (userInfo.getEmergencyContact2() != null && !userInfo.getEmergencyContact2().trim().isEmpty()) {
+            // 테스트용으로 모든 가족 연락처는 testPhoneNumber로 발송
+            // String convertedNumber = convertToInternationalFormat(userInfo.getEmergencyContact2());
+            // allSent &= sendSingleSms(convertedNumber, "[Family Emergency 2] " + message);
+            allSent &= sendSingleSms(testPhoneNumber, "[Family Emergency 2] " + message);
+            log.info("가족2에게 SMS 발송 완료: {} -> {}", userInfo.getEmergencyContact2(), testPhoneNumber);
+        }
+        
+        if (userInfo.getEmergencyContact3() != null && !userInfo.getEmergencyContact3().trim().isEmpty()) {
+            // 테스트용으로 모든 가족 연락처는 testPhoneNumber로 발송
+            // String convertedNumber = convertToInternationalFormat(userInfo.getEmergencyContact3());
+            // allSent &= sendSingleSms(convertedNumber, "[Family Emergency 3] " + message);
+            allSent &= sendSingleSms(testPhoneNumber, "[Family Emergency 3] " + message);
+            log.info("가족3에게 SMS 발송 완료: {} -> {}", userInfo.getEmergencyContact3(), testPhoneNumber);
+        }
+        
+        return allSent;
+    }
+    
+    private boolean sendSingleSms(String to, String messageBody) {
+        try {
+            Message twilioMessage = Message.creator(
+                new PhoneNumber(to),
+                new PhoneNumber(twilioConfig.getPhoneNumber()),
+                messageBody
+            ).create();
+            
+            log.info("SMS 발송 성공 - SID: {}, To: {}", twilioMessage.getSid(), to);
+            return true;
+        } catch (Exception e) {
+            log.error("SMS 발송 실패 - To: {}, Error: {}", to, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/global/config/TwilioConfig.java
+++ b/src/main/java/com/smooth/drivecast_service/global/config/TwilioConfig.java
@@ -1,0 +1,21 @@
+package com.smooth.drivecast_service.global.config;
+
+import com.twilio.Twilio;
+import jakarta.annotation.PostConstruct;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "twilio")
+@Data
+public class TwilioConfig {
+    private String accountSid;
+    private String authToken;
+    private String phoneNumber;
+
+    @PostConstruct
+    public void initTwilio() {
+        Twilio.init(accountSid, authToken);
+    }
+}


### PR DESCRIPTION
## 목적
- 응급 문자 전송 로직 구현

---

## 구현/변경 사항
- 응급 문자 전송 로직을 구현했습니다.
- sms 서비스를 따로 분리했습니다.
- twilio 외부 서비스를 연동하여 구현했습니다.

---

## 참고
- 가상 번호 -> 가상 번호로 문자 전송이 가게 됩니다.
- 원래 흐름은 응급 가족 연락처 3개 (최대)로 가족 문자 알림이 가게 되지만 현재는 가상 번호 1개로 문자 전송이 가게 됩니다.
---
