### PR TITLE
 PR: T5.3.3 - 응급 연락처 조회 및 feign 구현 → US5.3 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/emergency/feign/InternalController.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/feign/InternalController.java
@@ -1,0 +1,28 @@
+package com.smooth.drivecast_service.emergency.feign;
+
+import com.smooth.drivecast_service.emergency.feign.dto.EmergencyReportDto;
+import com.smooth.drivecast_service.emergency.service.EmergencyReportService;
+import com.smooth.drivecast_service.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/internal/v1", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class InternalController {
+    private final EmergencyReportService emergencyReportService;
+
+    @GetMapping(value = "/users/{userId}/accidents")
+    public ApiResponse<List<EmergencyReportDto>> getUserAccidents(@PathVariable("userId") String userId) {
+        List<EmergencyReportDto> accidents = emergencyReportService.getUserAccidents(userId);
+        return ApiResponse.success("유저 사고 이력 조회 완료", accidents);
+    }
+}

--- a/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClient.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClient.java
@@ -1,0 +1,12 @@
+package com.smooth.drivecast_service.emergency.feign;
+
+import com.smooth.drivecast_service.emergency.feign.dto.EmergencyInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service", url = "http://localhost:8081", path = "internal/v1/users", fallback = UserServiceClientFallback.class)
+public interface UserServiceClient {
+    @GetMapping("/{userId}/emergency-info")
+    EmergencyInfoResponse getUserInfo(@PathVariable("userId") String userId);
+}

--- a/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClientFallback.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClientFallback.java
@@ -1,0 +1,29 @@
+package com.smooth.drivecast_service.emergency.feign;
+
+import com.smooth.drivecast_service.emergency.feign.dto.EmergencyInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UserServiceClientFallback implements UserServiceClient {
+    @Override
+    public EmergencyInfoResponse getUserInfo(String userId) {
+        log.error("유저 서비스 장애 userId = {}", userId);
+
+        EmergencyInfoResponse.EmergencyData fallbackData = EmergencyInfoResponse.EmergencyData.builder()
+                .userId(userId)
+                .gender("Unknown")
+                .bloodType("Unknown")
+                .emergencyContact1(null)
+                .emergencyContact2(null)
+                .emergencyContact3(null)
+                .build();
+
+        return EmergencyInfoResponse.builder()
+                .code("SERVICE_UNAVAILABLE")
+                .message("유저 서비스 장애로 인한 기본 정보")
+                .data(fallbackData)
+                .build();
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -49,3 +49,11 @@ logging:
     com.smooth.drivecast_service: INFO
     org.springframework.data.redis: WARN
     org.hibernate: WARN
+
+twilio:
+  account-sid: ${TWILIO_SID}
+  auth-token: ${TWILIO_TOKEN}
+  phone-number: ${TWILIO_NUMBER}
+
+test:
+  phone-number: ${TWILIO_TEST_NUMBER}


### PR DESCRIPTION
#  PR: T5.3.3 - 응급 연락처 조회 및 feign 구현 → US5.3 머지

## 목적
- 다른 서비스 요청, 응답에 필요한 feign 구현하여 US5.3 119 신고 서비스에 머지합니다.

---

## 구현/변경 사항
- DC -> US  : 119 응급 정보 조회 및 보호자 연락처 조회를 위한 feign 기능을 구현했습니다.
- 마이페이지 (외부) -> DC : 내 사고 이력 조회를 위한 feign 기능을 구현했습니다. 
- AC -> DC : 사고 조회(119 신고 이력 조회)를 위한 feign 기능을 구현했습니다.

---

## 참고
- 119 신고 테이블 : 유저 아이디, 사고 아이디, 위도, 경도, 119 신고 시간, 119 전송 유무, 가족 알림 유무
- 관련 이슈/유저 스토리: #22 , #4 