### PR TITLE
PR: refactor - US5.2 성향 API 연동 및 구조 개선 → feat-US5.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
       - DB_USER=${DB_USER:-drivecast}
       - DB_PASSWORD=${DB_PASSWORD}
 
+      # OpenFeign
+      - CLIENT_USER=${CLIENT_USER}
+
       # JWT Configuration
       - JWT_SECRET=${JWT_SECRET}
       - JWT_EXPIRATION=${JWT_EXPIRATION:-86400000}
@@ -63,23 +66,23 @@ services:
       timeout: 3s
       retries: 3
 
-  # 위치 데이터용 Valkey (Redis 호환) - AWS ElastiCache 사용시 주석 처리
-  valkey:
-    image: valkey/valkey:7.2-alpine
-    container_name: valkey
-    volumes:
-      - valkey-data:/data
-    networks:
-      - drivecast-network
-    restart: unless-stopped
-    command: valkey-server --appendonly yes
-    healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    profiles:
-      - local  # 로컬 개발시에만 실행
+#  # 위치 데이터용 Valkey (Redis 호환) - AWS ElasticCache 사용시 주석 처리
+#  valkey:
+#    image: valkey/valkey:7.2-alpine
+#    container_name: valkey
+#    volumes:
+#      - valkey-data:/data
+#    networks:
+#      - drivecast-network
+#    restart: unless-stopped
+#    command: valkey-server --appendonly yes
+#    healthcheck:
+#      test: ["CMD", "valkey-cli", "ping"]
+#      interval: 10s
+#      timeout: 3s
+#      retries: 3
+#    profiles:
+#      - local # 로컬 개발시에만 실행
 
   # MySQL Database
   mysql-db:

--- a/src/main/java/com/smooth/drivecast_service/driving/feign/UserTraitClient.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/feign/UserTraitClient.java
@@ -11,20 +11,21 @@ import org.springframework.web.bind.annotation.RequestParam;
  * 유저 서비스 성향 조회 Feign 클라이언트
  */
 @FeignClient(
-        name = "user-service",
-        url = "${app.client.user-service.url}"
+        name = "driving-analysis-service",
+        url = "${app.client.driving-analysis-service.url}",
+        path = "/internal/v1"
 )
 public interface UserTraitClient {
 
     /**
      * 단건 성향 조회
      */
-    @GetMapping("/internal/v1/traits/{userId}")
+    @GetMapping("/characters/{userId}")
     TraitResponseDto getTrait(@PathVariable String userId);
 
     /**
      * 벌크 성향 조회
      */
-    @GetMapping("/internal/v1/traits/bulk")
+    @GetMapping("/characters")
     TraitBulkResponseDto getTraitsBulk(@RequestParam(defaultValue = "true") boolean hasCharacter);
 }

--- a/src/main/java/com/smooth/drivecast_service/driving/feign/test/MockUserTraitController.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/feign/test/MockUserTraitController.java
@@ -24,7 +24,7 @@ import java.util.Random;
 @ConditionalOnProperty(name = "mock.user-service.enabled", havingValue = "true")
 public class MockUserTraitController {
 
-    private static final String[] CHARACTERS = {"dolphin", "lion", "eagle", "bear", "fox", "rabbit"};
+    private static final String[] CHARACTERS = {"DOLPHIN", "LION", "CAT", "MEARCAT"};
     private static final Random random = new Random();
 
     /**

--- a/src/main/java/com/smooth/drivecast_service/driving/service/DrivingSessionManager.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/DrivingSessionManager.java
@@ -1,7 +1,7 @@
 package com.smooth.drivecast_service.driving.service;
 
 import com.smooth.drivecast_service.driving.constants.DrivingVicinityPolicy;
-import lombok.RequiredArgsConstructor;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,11 +16,13 @@ import java.util.concurrent.TimeUnit;
  **/
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class DrivingSessionManager {
 
-    @Qualifier("stringRedisTemplate")
     private final StringRedisTemplate stringRedisTemplate;
+
+    public DrivingSessionManager(@Qualifier("stringRedisTemplate") StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
 
     /**
      * 활성 세트에 사용자 추가

--- a/src/main/java/com/smooth/drivecast_service/driving/service/DrivingTraitService.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/DrivingTraitService.java
@@ -26,7 +26,7 @@ public class DrivingTraitService {
 
     // 유효한 성향 enum 값들 (검증용)
     private static final Set<String> VALID_CHARACTERS = Set.of(
-            "dolphin", "lion", "meerkat", "cat"
+            "DOLPHIN", "LION", "MEERCAT", "CAT"
     );
 
     /**

--- a/src/main/java/com/smooth/drivecast_service/driving/service/TraitCacheService.java
+++ b/src/main/java/com/smooth/drivecast_service/driving/service/TraitCacheService.java
@@ -2,7 +2,7 @@ package com.smooth.drivecast_service.driving.service;
 
 import com.smooth.drivecast_service.driving.constants.DrivingVicinityPolicy;
 import com.smooth.drivecast_service.global.exception.BusinessException;
-import lombok.RequiredArgsConstructor;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -20,13 +20,16 @@ import java.util.concurrent.TimeUnit;
  **/
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class TraitCacheService {
 
-    @Qualifier("stringRedisTemplate")
     private final RedisTemplate<String, String> redisTemplate;
-
     private final DrivingTraitService drivingTraitService;
+
+    public TraitCacheService(@Qualifier("stringRedisTemplate") RedisTemplate<String, String> redisTemplate,
+                           DrivingTraitService drivingTraitService) {
+        this.redisTemplate = redisTemplate;
+        this.drivingTraitService = drivingTraitService;
+    }
 
     /**
      * 새벽 1시 성향 워밍 캐시 실행

--- a/src/main/java/com/smooth/drivecast_service/global/util/KoreanTimeUtil.java
+++ b/src/main/java/com/smooth/drivecast_service/global/util/KoreanTimeUtil.java
@@ -13,20 +13,45 @@ public class KoreanTimeUtil {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter KOREAN_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final DateTimeFormatter KOREAN_FORMATTER_NO_SECONDS = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
     private static final DateTimeFormatter LOCATION_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     /**
      * 한국시 문자열을 Instant로 변환
-     * 입력: "2025-08-04T17:03:00" (한국시)
+     * 입력: "2025-08-04T17:03:00" 또는 "2025-08-04T17:03" (한국시)
      * 출력: Instant (UTC)
      */
     public static Instant parseKoreanTime(String koreanTimeString) {
+        try {
+            LocalDateTime localDateTime;
+            
+            // 먼저 초가 포함된 형태로 파싱 시도
+            try {
+                localDateTime = LocalDateTime.parse(koreanTimeString, KOREAN_FORMATTER);
+            } catch (Exception e) {
+                // 초가 없는 형태로 파싱 시도
+                localDateTime = LocalDateTime.parse(koreanTimeString, KOREAN_FORMATTER_NO_SECONDS);
+            }
+            
+            ZonedDateTime koreanTime = localDateTime.atZone(KOREA_ZONE);
+            return koreanTime.toInstant();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("한국시 파싱 실패: " + koreanTimeString, e);
+        }
+    }
+
+    /**
+     * Incident 전용 - 초단위까지 필수인 한국시 문자열을 Instant로 변환
+     * 입력: "2025-08-04T17:03:00" (한국시, 초 필수)
+     * 출력: Instant (UTC)
+     */
+    public static Instant parseKoreanTimeWithSeconds(String koreanTimeString) {
         try {
             LocalDateTime localDateTime = LocalDateTime.parse(koreanTimeString, KOREAN_FORMATTER);
             ZonedDateTime koreanTime = localDateTime.atZone(KOREA_ZONE);
             return koreanTime.toInstant();
         } catch (Exception e) {
-            throw new IllegalArgumentException("한국시 파싱 실패: " + koreanTimeString, e);
+            throw new IllegalArgumentException("한국시 파싱 실패 (초단위 필수): " + koreanTimeString, e);
         }
     }
 

--- a/src/main/java/com/smooth/drivecast_service/global/util/ValidationUtil.java
+++ b/src/main/java/com/smooth/drivecast_service/global/util/ValidationUtil.java
@@ -50,6 +50,19 @@ public final class ValidationUtil {
     }
 
     /**
+     * Incident 전용 엄격한 타임스탬프 검증 (초단위 필수)
+     * @param timestamp 타임스탬프 문자열
+     * @return "yyyy-MM-ddTHH:mm:ss" 형식이면 true
+     **/
+    public static boolean hasValidIncidentTimestampFormat(String timestamp) {
+        if (timestamp == null || timestamp.isBlank()) return false;
+        // "2025-08-27T09:23:45" 형태 (19자) 체크
+        if (timestamp.length() != 19) return false;
+        // 기본 패턴 체크: yyyy-MM-ddTHH:mm:ss
+        return timestamp.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}");
+    }
+
+    /**
      * 숫자 범위 검증 (정책 없음)
      * @param value 검증할 값
      * @param min 최소값

--- a/src/main/java/com/smooth/drivecast_service/incident/dto/IncidentEvent.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/dto/IncidentEvent.java
@@ -31,8 +31,8 @@ public record IncidentEvent(
             throw new BusinessException(IncidentErrorCode.MISSING_TIMESTAMP);
         }
 
-        // 위치 좌표 범위 검증
-        if (!ValidationUtil.hasValidTimestampFormat(timestamp)) {
+        // Incident는 초단위 정확성이 중요하므로 엄격한 검증 적용
+        if (!ValidationUtil.hasValidIncidentTimestampFormat(timestamp)) {
             throw new BusinessException(IncidentErrorCode.INVALID_TIMESTAMP_FORMAT);
         }
 

--- a/src/main/java/com/smooth/drivecast_service/incident/service/IncidentEventHandler.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/service/IncidentEventHandler.java
@@ -102,8 +102,8 @@ public class IncidentEventHandler {
 
     private void sendToNearbyUsers(IncidentEvent event, String alertId, boolean excludeSelf) {
         try {
-            // 반경 내 사용자 검색
-            Instant refTime = KoreanTimeUtil.parseKoreanTime(event.timestamp());
+            // 반경 내 사용자 검색 (Incident는 초단위 정확성 필수)
+            Instant refTime = KoreanTimeUtil.parseKoreanTimeWithSeconds(event.timestamp());
             List<String> nearbyUsers = vicinityService.findUsers(
                     event.latitude(),
                     event.longitude(),

--- a/src/main/java/com/smooth/drivecast_service/incident/service/mapper/AccidentMessageMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/incident/service/mapper/AccidentMessageMapper.java
@@ -25,6 +25,7 @@ public class AccidentMessageMapper implements  IncidentMessageMapper{
                 return Optional.of(new IncidentResponseDto(
                         "accident",
                         Map.of(
+                                "accidentId", context.getEvent().accidentId(),
                                 "title", "큰 사고가 발생했습니다!",
                                 "content", "차량에 큰 사고가 감지되었습니다. 부상이 있다면 즉시 구조를 요청하세요."
                         )

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,6 +31,17 @@ spring:
         format_sql: false
         show_sql: false
 
+mock:
+  user-service:
+    enabled: true # 유저 서비스 feign 개발 전까지 사용
+
+app:
+  client:
+    user-service:
+      url: ${CLIENT_USER}
+    driving-analysis-service:
+      url: ${CLIENT_DRIVING_ANALYSIS}
+
 jwt:
   secret: ${JWT_SECRET}  # 환경변수 필수
   expiration: ${JWT_EXPIRATION:86400000}  # 24시간 기본값
@@ -45,7 +56,23 @@ valkey:
 
 logging:
   level:
-    org.springframework.web: WARN
+    root: INFO
+    # 우리 서비스 로그는 INFO 레벨 (운영 환경)
     com.smooth.drivecast_service: INFO
+    # 주요 비즈니스 로직은 DEBUG로 상세 추적 가능
+    com.smooth.drivecast_service.driving.service.DrivingBroadcastScheduler: DEBUG
+    com.smooth.drivecast_service.driving.service.DrivingVicinityService: DEBUG
+    com.smooth.drivecast_service.driving.service.TraitCacheService: INFO
+    # Redis 연결 로그 최소화 (운영 환경)
     org.springframework.data.redis: WARN
+    org.springframework.data.redis.core.RedisConnectionUtils: ERROR
+    # HTTP 관련 로그 최소화 (운영 환경)
+    org.springframework.web: WARN
+    org.springframework.web.servlet.DispatcherServlet: WARN
+    # Hibernate 로그 최소화 (운영 환경)
     org.hibernate: WARN
+    org.hibernate.SQL: WARN
+    # Feign 클라이언트 로그 최소화 (운영 환경)
+    feign: WARN
+    # 스케줄러 로그 제어
+    org.springframework.scheduling: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,4 +34,13 @@ server:
 logging:
   level:
     root: INFO
-    com.smooth.drivecast_service: INFO
+    com.smooth.drivecast_service: DEBUG
+    # Redis 연결 로그 최소화
+    org.springframework.data.redis.core.RedisConnectionUtils: WARN
+    org.springframework.data.redis.connection: WARN
+    # 스케줄러 관련 로그 제어
+    org.springframework.scheduling: INFO
+    # HTTP 요청 로그 (개발용)
+    org.springframework.web.servlet.DispatcherServlet: DEBUG
+    # Feign 클라이언트 로그 (개발용)
+    feign: DEBUG


### PR DESCRIPTION
# PR: refactor - US5.2 성향 API 연동 및 구조 개선 → feat-US5.2

## 목적
- 성향 API(`driving-analysis-service`) 연동
- 주행/사고 처리 구조 및 캐시/세션 관리 개선

## 주요 변경
- **UserTraitClient**: `/characters` 기반 API 호출 변경
- **TraitCacheService/DrivingTraitService**: 캐시 + API 연동 구조 적용
- **DrivingSessionManager/DrivingBroadcastScheduler**: 활성 세션 관리 + 1Hz 브로드캐스트
- **Incident 처리**: 초 단위 타임스탬프 검증 강화, accidentId 포함
- **환경설정**: yml 로깅/Feign/Redis 설정 정리

## 참고
- Refs: US 5.2 / T5.2.2
- Mock API: `mock.user-service.enabled=true`  