### PR TITLE
PR: refactor - US5.3 feign 주소 변경 → feat-US5.3 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClient.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClient.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "user-service", url = "http://localhost:8081", path = "internal/v1/users", fallback = UserServiceClientFallback.class)
+@FeignClient(name = "user-service", url = "${app.client.user-service.url}", path = "internal/v1/users", fallback = UserServiceClientFallback.class)
 public interface UserServiceClient {
     @GetMapping("/{userId}/emergency-info")
     EmergencyInfoResponse getUserInfo(@PathVariable("userId") String userId);


### PR DESCRIPTION
# PR: refactor - US5.3 feign 주소 변경 → feat-US5.3 머지

## 목적
- US5.3 리팩토링 완료 후 US5.3 머지

## 주요 변경
- 하드코딩 주소로 되어있던 feign client 코드를 환경 변수 주소로 변경했습니다.
- UserServiceCient.java

## 참고
- Refs: US 5.3
