### PR TITLE
PR: refactor - US5.3 위도 경도 타입 및 prod 환경 설정 → feat-US5.3 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/emergency/entity/EmergencyReport.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/entity/EmergencyReport.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -34,10 +35,10 @@ public class EmergencyReport {
     private LocalDateTime reportTime;
 
     @Column(name = "latitude", nullable = true, precision = 8, scale = 5)
-    private Double latitude;
+    private BigDecimal latitude;
 
     @Column(name = "longitude", nullable = true, precision = 8, scale = 5)
-    private Double longitude;
+    private BigDecimal longitude;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/smooth/drivecast_service/emergency/feign/dto/EmergencyReportDto.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/feign/dto/EmergencyReportDto.java
@@ -1,5 +1,6 @@
 package com.smooth.drivecast_service.emergency.feign.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record EmergencyReportDto(
@@ -9,7 +10,7 @@ public record EmergencyReportDto(
         Boolean emergencyNotified,
         Boolean familyNotified,
         LocalDateTime reportTime,
-        Double latitude,
-        Double longitude
+        BigDecimal latitude,
+        BigDecimal longitude
 ) {
 }

--- a/src/main/java/com/smooth/drivecast_service/emergency/service/EmergencyReportService.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/service/EmergencyReportService.java
@@ -4,6 +4,8 @@ import com.smooth.drivecast_service.emergency.feign.UserServiceClient;
 import com.smooth.drivecast_service.emergency.feign.dto.EmergencyInfoResponse;
 import com.smooth.drivecast_service.emergency.service.mapper.EmergencyMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
 import com.smooth.drivecast_service.emergency.dto.AccidentInfoDto;
 import com.smooth.drivecast_service.emergency.dto.EmergencyReportResult;
 import com.smooth.drivecast_service.emergency.dto.EmergencyRequestDto;
@@ -79,8 +81,8 @@ public class EmergencyReportService {
             try {
                 AccidentInfoDto accidentInfo = getAccidentInfo(req.getAccidentId());
                 if (accidentInfo != null) {
-                    report.setLatitude(accidentInfo.getLatitude());
-                    report.setLongitude(accidentInfo.getLongitude());
+                    report.setLatitude(accidentInfo.getLatitude() != null ? BigDecimal.valueOf(accidentInfo.getLatitude()) : null);
+                    report.setLongitude(accidentInfo.getLongitude() != null ? BigDecimal.valueOf(accidentInfo.getLongitude()) : null);
                 }
             } catch (Exception e) {
                 log.warn("사고 정보 조회 실패 - 위치 정보 없이 저장: accidentId={}", req.getAccidentId());

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -33,7 +33,7 @@ spring:
 
 mock:
   user-service:
-    enabled: true # 유저 서비스 feign 개발 전까지 사용
+    enabled: false # 유저 서비스 feign 개발 전까지 사용
 
 app:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,22 @@ jwt:
 server:
   port: 8080
 
+app:
+  client:
+    user-service:
+      url: ${CLIENT_USER}
+    driving-analysis-service:
+      url: ${CLIENT_DRIVING_ANALYSIS}
+
+twilio:
+  account-sid: ${TWILIO_SID}
+  auth-token: ${TWILIO_TOKEN}
+  phone-number: ${TWILIO_NUMBER}
+
+test:
+  phone-number: ${TWILIO_TEST_NUMBER}
+
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
# PR: refactor - US5.3 위도 경도 타입 및 prod 환경 설정 → feat-US5.3 머지

## 목적
- US5.3 리팩토링 완료 후 US5.3 머지

## 주요 변경
- 위도 경도 타입이 `Double`이라 mysql 테이블 생성 문제가 생겨 타입을 `BigDecimal` 으로 변경했습니다.
- 서비스 코드에서 위도 경도 null 처리를 추가했습니다.
- .yml에서 문자 전송 서비스를 위한 twilio 설정을 추가하고 prob.yml에서 개발용 User feign 설정을 false 로 변경했습니다.
```
mock:
  user-service:
    enabled: false 
```


## 참고
- Refs: US 5.3
