### PR TITLE
PR: US5.3 - 119 자동 신고 서비스 리팩토링 → dev 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
 	// Feign (optional)
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/smooth/drivecast_service/emergency/entity/EmergencyReport.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/entity/EmergencyReport.java
@@ -9,7 +9,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "emergency_reports")
+@Table(name = "emergency_reports", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"accident_id", "user_id"}))
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClientFallback.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/feign/UserServiceClientFallback.java
@@ -13,8 +13,8 @@ public class UserServiceClientFallback implements UserServiceClient {
 
         EmergencyInfoResponse.EmergencyData fallbackData = EmergencyInfoResponse.EmergencyData.builder()
                 .userId(userId)
-                .gender("Unknown")
-                .bloodType("Unknown")
+                .gender("미상")
+                .bloodType("미상")
                 .emergencyContact1(null)
                 .emergencyContact2(null)
                 .emergencyContact3(null)

--- a/src/main/java/com/smooth/drivecast_service/emergency/repository/EmergencyReportRepository.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/repository/EmergencyReportRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface EmergencyReportRepository extends JpaRepository<EmergencyReport, Long> {
 
     boolean existsByAccidentIdAndUserIdAndEmergencyNotifiedTrue(String accidentId, Long userId);
+    
+    boolean existsByAccidentIdAndUserId(String accidentId, Long userId);
 
     List<EmergencyReport> findByUserIdOrderByReportTimeDesc(Long userId);
 }

--- a/src/main/java/com/smooth/drivecast_service/emergency/service/mapper/EmergencyMapper.java
+++ b/src/main/java/com/smooth/drivecast_service/emergency/service/mapper/EmergencyMapper.java
@@ -2,10 +2,33 @@ package com.smooth.drivecast_service.emergency.service.mapper;
 
 import com.smooth.drivecast_service.emergency.dto.EmergencyUserInfoDto;
 import com.smooth.drivecast_service.emergency.feign.dto.EmergencyInfoResponse;
-import org.mapstruct.Mapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
-@Mapper(componentModel = "spring")
-public interface EmergencyMapper {
+@Slf4j
+@Component
+public class EmergencyMapper {
     
-    EmergencyUserInfoDto toUserInfoDto(EmergencyInfoResponse.EmergencyData data);
+    public EmergencyUserInfoDto toUserInfoDto(EmergencyInfoResponse.EmergencyData data) {
+        if (data == null) {
+            log.warn("EmergencyData가 null입니다. 기본값 반환");
+            EmergencyUserInfoDto defaultDto = new EmergencyUserInfoDto();
+            defaultDto.setGender("미상");
+            defaultDto.setBloodType("미상");
+            return defaultDto;
+        }
+        
+        EmergencyUserInfoDto dto = new EmergencyUserInfoDto();
+        dto.setUserId(data.getUserId());
+        dto.setGender(data.getGender());
+        dto.setBloodType(data.getBloodType());
+        dto.setEmergencyContact1(data.getEmergencyContact1());
+        dto.setEmergencyContact2(data.getEmergencyContact2());
+        dto.setEmergencyContact3(data.getEmergencyContact3());
+        
+        log.debug("수동 매핑 완료: userId={}, gender={}, bloodType={}, contact1={}", 
+            dto.getUserId(), dto.getGender(), dto.getBloodType(), dto.getEmergencyContact1());
+        
+        return dto;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
 
   cloud:
     openfeign:
+      circuitbreaker:
+        enabled: true
       client:
         config:
           default:


### PR DESCRIPTION
# PR: US5.3 - 119 자동 신고 서비스 리팩토링 → dev 머지

## 목적
- 119 응급 신고 서비스 성능 개선을 위한 리팩토링
- open feign 매핑 문제 해결
---

## 구현/변경 사항

- DB에 중복 저장을 방지하기 위해 엔티티 부분에 유니크 제약을 추가했습니다.
- feign fallback 의존성 및 application.yml에 설정을 추가했습니다.
- 하나의 트랜잭션이었던 119 신고 서비스를 2개의 트랜잭션으로 분리했습니다.
- 트랙잭션으로 분리하며 private 메소드를 protect로 변경했습니다.
-> 신고 기록 저장(제 1 트랜잭션) / 외부 서비스 조회(트랙잭션으로부터 분리) / 알림 발송 및 완료(제 2 트랜잭션)
- open feign시 유저 정보가 조회가 되나 매핑 실패 되어 문자 전송 시 디폴트 값으로 전송되는 문제가 있었습니다. 의존성인 mapstruct을 제거하고 수동 매핑으로 전환하여 문제를 해결했습니다.

---

## 테스트
- 유저 서비스와의 feign 테스트 완료
- 수동 매핑 검증 완료
- 로컬에서의 문자 전송 테스트 완료

## 참고
- **관련 이슈/유저 스토리**: Refs: #4 