### PR TITLE
PR: refactor - DEV WebSocket 설정 개선 (허용 오리진, 스케줄러, 하트비트 조정) → dev 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/global/config/WebSocketConfig.java
+++ b/src/main/java/com/smooth/drivecast_service/global/config/WebSocketConfig.java
@@ -4,6 +4,7 @@ import com.smooth.drivecast_service.global.security.JwtTokenProvider;
 import com.smooth.drivecast_service.global.security.StompPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
@@ -29,16 +30,19 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Bean
     public ThreadPoolTaskScheduler brokerTaskScheduler() {
         ThreadPoolTaskScheduler ts = new ThreadPoolTaskScheduler();
-        ts.setPoolSize(1);
+        ts.setPoolSize(2);
         ts.setThreadNamePrefix("ws-heartbeat-");
         ts.initialize();
         return ts;
     }
 
+    @Value("${ws.allowed-origins}")
+    private String[] allowedOrigins;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS();
     }
 
@@ -46,7 +50,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/queue", "/topic")
                 .setTaskScheduler(brokerTaskScheduler())
-                .setHeartbeatValue(new long[]{10000, 10000});
+                .setHeartbeatValue(new long[]{30000, 30000});
         registry.setApplicationDestinationPrefixes("/app");
         registry.setUserDestinationPrefix("/user");
     }


### PR DESCRIPTION
# PR: refactor - DEV WebSocket 설정 개선 (허용 오리진, 스케줄러, 하트비트 조정) → dev 머지

## 목적
- WebSocket 통신의 안정성과 보안을 강화
- 하트비트 주기 및 스케줄러 풀 설정 최적화

---

## 구현/변경 사항
- **ThreadPoolTaskScheduler**
  - 풀 사이즈 1 → 2로 확장 (동시성 향상)
- **허용 오리진(CORS)**
  - 기존 `*` 와일드카드 허용 제거
  - `ws.allowed-origins` 환경 변수 기반으로 제한적 허용
- **하트비트 주기**
  - 10초 → 30초로 완화하여 불필요한 네트워크 부하 감소

---

## 참고
- 운영 환경에서는 반드시 `ws.allowed-origins` 값 지정 필요
- 향후 외부 브로커 도입 시 추가 설정 고려
- **관련 이슈/유저 스토리**: Refs: #3 