### PR TITLE
PR: refactor - DEV WebSocket 엔드포인트 "/ws" → "/wss" 변경 → dev 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/global/config/WebSocketConfig.java
+++ b/src/main/java/com/smooth/drivecast_service/global/config/WebSocketConfig.java
@@ -41,7 +41,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws")
+        registry.addEndpoint("/wss")
                 .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS();
     }


### PR DESCRIPTION
# PR: refactor - DEV WebSocket 엔드포인트 "/ws" → "/wss" 변경 → dev 머지

## 목적
- WebSocket 엔드포인트를 HTTPS 환경에 맞게 `/wss`로 변경
- 클라이언트 연결 시 보안 프로토콜(WebSocket Secure) 사용 보장

---

## 구현/변경 사항
- **WebSocketConfig**
  - STOMP 엔드포인트 경로 `/ws` → `/wss`로 수정
  - allowedOrigins 및 SockJS 설정은 기존과 동일 유지

---

## 참고
- 클라이언트 측 WebSocket 연결 URL도 `/wss`로 맞춰야 정상 동작
- 추후 운영 환경 배포 시 SSL 인증서와 함께 테스트 필요
- **관련 이슈/유저 스토리**: Refs: #1