### PR TITLE
PR: fix - DEV WebSocket 엔드포인트 /wss → /ws 복원 → dev 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/global/config/WebSocketConfig.java
+++ b/src/main/java/com/smooth/drivecast_service/global/config/WebSocketConfig.java
@@ -41,7 +41,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/wss")
+        registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS();
     }


### PR DESCRIPTION
# PR: fix - DEV WebSocket 엔드포인트 /wss → /ws 복원 → dev 머지

## 목적
- 클라이언트 접속 경로 혼선을 방지하기 위해 WebSocket 엔드포인트를 `/wss`에서 `/ws`로 복원합니다.
- SockJS 기반 연결 시 일관된 URL을 유지합니다.

---

## 구현/변경 사항
- `WebSocketConfig`에서 STOMP 엔드포인트를 `/wss` → `/ws`로 수정
- 클라이언트와 서버 간 접속 경로 통일

---

## 참고
- SockJS 사용 시 프로토콜(`ws://`, `wss://`)은 자동 처리되므로 경로는 `/ws`로 유지하는 것이 표준적임