### PR TITLE
fix: RedisConfig에 기본 Redis 연결 및 StringRedisTemplate 빈 추가

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/global/config/RedisConfig.java
+++ b/src/main/java/com/smooth/drivecast_service/global/config/RedisConfig.java
@@ -24,9 +24,44 @@ public class RedisConfig {
     @Value("${valkey.password:}")
     private String valkeyPassword;
 
+    // 기본 Redis 설정값 (내부 캐시용)
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.database:0}")
+    private int redisDatabase;
+
+    @Value("${spring.data.redis.password:}")
+    private String redisPassword;
+
     /**
-     * 기본 Redis는 Spring Boot 자동 설정 사용 (캐시용)
-     * 기본 RedisTemplate은 Spring Boot가 자동 생성 (캐시용으로 사용) */
+     * 기본 Redis 연결 팩토리 (내부 캐시용)
+     */
+    @Bean
+    public JedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisHost);
+        config.setPort(redisPort);
+        config.setDatabase(redisDatabase);
+        if (!redisPassword.isEmpty()) {
+            config.setPassword(redisPassword);
+        }
+        return new JedisConnectionFactory(config);
+    }
+
+    /**
+     * 기본 Redis용 StringRedisTemplate (내부 캐시용)
+     */
+    @Bean
+    public org.springframework.data.redis.core.StringRedisTemplate stringRedisTemplate() {
+        org.springframework.data.redis.core.StringRedisTemplate template = 
+            new org.springframework.data.redis.core.StringRedisTemplate();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
 
     // Valkey용 별도 설정
     @Bean


### PR DESCRIPTION
# PR: fix - DEV RedisConfig 기본 Redis 연결 및 템플릿 추가 → dev 머지

## 목적
- 내부 캐시 처리를 위해 기본 Redis 연결과 `StringRedisTemplate`을 명시적으로 설정합니다.
- Valkey와의 역할 분리를 명확히 하여 캐시와 위치 데이터 처리를 구분합니다.

---

## 구현/변경 사항
- `spring.data.redis.*` 설정값(host, port, database, password) 주입 추가
- `JedisConnectionFactory` 기반 기본 Redis 연결 팩토리 빈 등록
- 기본 Redis용 `StringRedisTemplate` 빈 등록
- 기존 "Spring Boot 자동 설정" 의존 제거 후 명시적 Bean 구성으로 전환

---

## 참고
- 기본 Redis → 내부 캐시 처리 용도
- Valkey → 위치 데이터 및 외부 처리 용도