### PR TITLE
PR: fix - DEV RedisConfig 기본 RedisTemplate 추가 및 직렬화 설정 정비 → dev 머지

### DIFF
--- a/src/main/java/com/smooth/drivecast_service/global/config/RedisConfig.java
+++ b/src/main/java/com/smooth/drivecast_service/global/config/RedisConfig.java
@@ -57,9 +57,27 @@ public class RedisConfig {
      */
     @Bean
     public org.springframework.data.redis.core.StringRedisTemplate stringRedisTemplate() {
-        org.springframework.data.redis.core.StringRedisTemplate template = 
+        org.springframework.data.redis.core.StringRedisTemplate template =
             new org.springframework.data.redis.core.StringRedisTemplate();
         template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+
+    /**
+     * 기본 RedisTemplate (Spring Boot 자동 설정 대체)
+     */
+    @Bean
+    public RedisTemplate<Object, Object> redisTemplate() {
+        RedisTemplate<Object, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setKeySerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
+        
+        template.afterPropertiesSet();
         return template;
     }
 


### PR DESCRIPTION
# PR: fix - DEV RedisConfig 기본 RedisTemplate 추가 및 직렬화 설정 정비 → dev 머지

## 목적
- 내부 캐시 로직에서 일관된 Redis 접근을 위해 `RedisTemplate`/`StringRedisTemplate`을 명시적으로 구성하고 직렬화를 통일합니다.

---

## 구현/변경 사항
- 기본 Redis 연결 팩토리(`JedisConnectionFactory`) 기반 `redisTemplate()` 빈 추가
- `StringRedisTemplate` 빈 명시 등록
- `RedisTemplate`에 `StringRedisSerializer`를 key/hashKey/value/hashValue 전부 적용
- 자동설정 의존 제거 → 명시적 Bean 구성으로 교체

---

## 참고
- 기본 Redis: 내부 캐시/세션 등 일반 용도
- Valkey RedisTemplate은 기존대로 위치/지오검색 용도 유지